### PR TITLE
fix: config.LANGUAGE_AUTOMATIC_DETECT has no effect

### DIFF
--- a/utils/nlp.py
+++ b/utils/nlp.py
@@ -1,7 +1,8 @@
 import regex as re
 from fastlid import fastlid
+import config
 
-fastlid.set_languages = ["zh", "ja"]
+fastlid.set_languages = config.LANGUAGE_AUTOMATIC_DETECT or ["zh", "ja"]
 
 
 def clasify_lang(text):


### PR DESCRIPTION
作者您好：
fastlid对中文和日文的错误识别率很高，但我尝试着去掉config.py中LANGUAGE_AUTOMATIC_DETECT配置项里的"ja"，fastlid却仍然会将中文识别为日文。阅读了源码后发现nlp.py中似乎并没有读取这一配置项，而是硬编码成了["zh", "ja"]，修改后中文识别正常。