### PR TITLE
Add japanese lang to vits-installer shell

### DIFF
--- a/vits-simple-api-installer-latest.sh
+++ b/vits-simple-api-installer-latest.sh
@@ -7,6 +7,7 @@ PLAIN='\033[0m'
 
 declare -A EN_MESSAGES
 declare -A ZH_MESSAGES
+declare -A JA_MESSAGES
 
 EN_MESSAGES=(
   ["ATTEMPT_DOWNLOAD"]="Attempting to download"
@@ -84,16 +85,59 @@ ZH_MESSAGES=(
   ["CONTAINERS_STARTING"]="容器正在启动"
 )
 
-echo -e "${PLAIN}${GREEN}Choose a language/选择语言: ${PLAIN}"
+JA_MESSAGES=(
+	["ATTEMPT_DOWNLOAD"]="ダウンロードを試みています"
+	["FROM"]="から"
+	["DOWNLOAD_FAIL"]="ダウンロードに失敗しました"
+	["FROM_ALL_URLS"]="提供されたすべてのURLから。"
+	["DOWNLOADING"]="ダウンロード中..."
+	["VERIFYING"]="検証中..."
+	["UNZIPPING"]="解凍中..."
+	["CREATE_PLACEHOLDER_FILE"]="プレースホルダーファイルを作成しました"
+	["CHOOSE_VERSION"]="どのバージョンのdocker-compose.yamlをダウンロードしますか？"
+	["DOCKER_CPU"]="docker-compose.yaml (CPUバージョン)"
+	["DOCKER_GPU"]="docker-compose-gpu.yaml (GPUバージョン)"
+	["NO_DOWNLOAD"]="YAMLファイルは既に存在しているため、ダウンロードの必要はありません"
+	["ENTER_CHOICE"]="選択肢を入力してください: "
+	["INVALID_CHOICE"]="無効な選択です。1、2、または3を入力してください。"
+	["DOWNLOAD_CONFIG"]="まもなく設定ファイルをダウンロードします..."
+	["PULL_IMAGE"]="イメージのプルを開始しますか？はいの場合は1を、いいえの場合は2を入力してください"
+	["DOWNLOAD_DICT"]="pyopenjtalk辞書ファイルをダウンロードしますか？はいの場合は1を、いいえの場合は2を入力してください"
+	["MUST_DOWNLOAD_JP"]="日本語モデルをダウンロードする必要があります。"
+	["DOWNLOAD_VITS_CHINESE"]="vits_chinese用のbertモデルをダウンロードしますか？はいの場合は1を、いいえの場合は2を入力してください。"
+	["MUST_DOWNLOAD_VITS_CHINESE"]="vits_chineseを使用するには、これらのモデルをダウンロードする必要があり、約410MBの容量が必要です。"
+	["DOWNLOAD_BERT_VITS2_1"]="chinese-roberta-wwm-ext-largeをダウンロードしますか？このモデルはフルバージョン用の中国語BERTモデルで、約1.21GBの容量を占めます。はいの場合は1を、いいえの場合は2を入力してください。"
+	["DOWNLOAD_BERT_VITS2_2"]="bert-base-japanese-v3をダウンロードしますか？このモデルはバージョン2.0以前に使用される日本語BERTモデルで、約426MBの容量を占めます。はいの場合は1を、いいえの場合は2を入力してください。"
+	["DOWNLOAD_BERT_VITS2_3"]="bert-large-japanese-v2をダウンロードしますか？はいの場合は1を、いいえの場合は2を入力してください。"
+	["DOWNLOAD_BERT_VITS2_4"]="deberta-v2-large-japaneseをダウンロードしますか？このモデルはバージョン2.0以降に使用される日本語BERTモデルで、約1.38GBの容量を占めます。はいの場合は1を、いいえの場合は2を入力してください。"
+	["DOWNLOAD_BERT_VITS2_5"]="deberta-v3-largeをダウンロードしますか？このモデルはバージョン2.0以降に使用される英語BERTモデルで、約835MBの容量を占めます。はいの場合は1を、いいえの場合は2を入力してください。"
+	["MUST_DOWNLOAD_BERT_VITS2"]="Bert-VITS2を使用するには、これらのモデルをダウンロードする必要があり、約1.63GBの容量が必要です。"
+	["DOWNLOADED"]="ファイルが正しくダウンロードされました。"
+	["CORRUPTED"]="ファイルがダウンロードされていないか、ダウンロードが不完全である可能性があります。また、ファイルが破損している可能性もあります。"
+	["INSTALL_COMPLETE"]="アップグレードまたはインストールが完了しました。"
+	["CONFIG_DIR"]="設定ファイルのディレクトリは以下の通りです"
+	["IMPORT_NOTICE"]="vitsモデルがインポートされていない場合、使用できません。設定ファイルのディレクトリでモデルをインポートしてください。"
+	["RESTART_NOTICE"]="設定ファイルを変更した後、変更を反映させるためにdockerコンテナを再起動してください。"
+	["ISSUE_NOTICE"]="何か質問がある場合は、イシューに投稿してください。"
+	["GITHUB_LINK"]="https://github.com/Artrajz/vits-simple-api"
+	["CONTAINERS_STARTING"]="コンテナが起動中です"
+)
+
+echo -e "${PLAIN}${GREEN}Choose a language/选择语言/言語: ${PLAIN}"
 echo "1. English"
 echo "2. 中文"
-read -p "Enter your choice (1 or 2): " choice_language
+echo "3. 日本語"
+read -p "Enter your choice (1 or 2 or 3): " choice_language
 
 declare -A MESSAGES
 if [ "$choice_language" -eq 1 ]; then
   for key in "${!EN_MESSAGES[@]}"; do
     MESSAGES["$key"]="${EN_MESSAGES[$key]}"
   done
+elif [ "$choice_language" -eq 3 ]; then
+	for key in "${!JA_MESSAGES[@]}"; do
+		MESSAGES["$key"]="${JA_MESSAGES[$key]}"
+	done
 else
   for key in "${!ZH_MESSAGES[@]}"; do
     MESSAGES["$key"]="${ZH_MESSAGES[$key]}"


### PR DESCRIPTION
Hello!

This change adds Japanese translation to vits-simple-api-installer-latest.sh. Vits is gaining interest in Japan as well. This will be helpful for Japanese users who are utilizing this repository.

If you think that the Japanese translation is not needed, feel free to close this.