### PR TITLE
Update `requirements.txt` with prebuild-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,31 +317,6 @@ After modification, select the reading engine, add the reading engine, paste the
 
 # Frequently Asked Questions
 
-## Installation Issues with fastText Dependency
-
-Fasttext may not be installed on windows, you can install it with the following command,or download wheels [here](https://www.lfd.uci.edu/~gohlke/pythonlibs/#fasttext)
-
-```bash
-# For Python 3.10 on win_amd64
-pip install https://github.com/Artrajz/archived/raw/main/fasttext/fasttext-0.9.2-cp310-cp310-win_amd64.whl
-```
-
-or
-
-```bash
-pip install fasttext -i https://pypi.artrajz.cn/simple
-```
-
-## Installation Issues with pyopenjtalk Dependency
-
-Since pypi.org does not provide a wheel file for pyopenjtalk, you often need to install it from the source code. This process might be cumbersome for some users, so you can also install it using a pre-built wheel as follows:
-
-```bash
-pip install pyopenjtalk -i https://pypi.artrajz.cn/simple
-```
-
-
-
 ## Bert-VITS2 Version Compatibility
 
 To ensure compatibility with the Bert-VITS2 model, modify the config.json file by adding a version parameter "version": "x.x.x". For instance, if the model version is 1.0.1, the configuration file should be written as:

--- a/README_zh.md
+++ b/README_zh.md
@@ -327,29 +327,6 @@ url中的IP可在API启动后找到，一般使用192.168开头的局域网IP。
 
 # 常见问题
 
-## fasttext依赖安装问题
-
-windows下可能安装不了fasttext,可以用以下命令安装，附[wheels下载地址](https://www.lfd.uci.edu/~gohlke/pythonlibs/#fasttext)
-
-```
-# python3.10 win_amd64
-pip install https://github.com/Artrajz/archived/raw/main/fasttext/fasttext-0.9.2-cp310-cp310-win_amd64.whl
-```
-
-或者
-
-```
-pip install fasttext -i https://pypi.artrajz.cn/simple
-```
-
-## pyopenjtalk依赖安装问题
-
-由于pypi.org没有pyopenjtalk的whl文件，通常需要从源代码来安装，这一过程对于一些人来说可能比较麻烦，所以你也可以使用我构建的whl来安装。
-
-```
-pip install pyopenjtalk -i https://pypi.artrajz.cn/simple
-```
-
 ## Bert-VITS2版本兼容
 
 修改Bert-VITS2模型的config.json，加入版本号参数`"version": "x.x.x"`，比如模型版本为1.0.1时，配置文件应该写成：

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ graiax-silkcoder[libsndfile]
 
 # Natural Language Processing and Text Conversion
 unidecode
-pyopenjtalk
+pyopenjtalk-prebuilt
 jamo
 pypinyin
 pypinyin-dict
@@ -22,7 +22,7 @@ ko_pron
 indic_transliteration
 num_thai
 opencc
-fasttext
+fasttext-wheel
 fastlid
 langid
 phonemizer==3.2.1


### PR DESCRIPTION
修复`fasttext`和`pyopenjtalk`因编译问题在 Windows 环境下易安装失败的问题。

Reference:
https://github.com/Plachtaa/VALL-E-X/issues/17#issuecomment-1691290220

https://github.com/facebookresearch/fastText/issues/1343#issuecomment-1662345725